### PR TITLE
Change query minimum duration to ms

### DIFF
--- a/backend/gen/serverhttp/api.gen.go
+++ b/backend/gen/serverhttp/api.gen.go
@@ -1070,7 +1070,7 @@ type GetQueriesRunningParams struct {
 	Instance    Instance    `form:"instance" json:"instance"`
 	Database    Database    `form:"database" json:"database"`
 
-	// MinDuration Minimum query duration in seconds
+	// MinDuration Minimum query duration in ms
 	MinDuration *int `form:"min_duration,omitempty" json:"min_duration,omitempty"`
 }
 

--- a/backend/internal/http/v1.go
+++ b/backend/internal/http/v1.go
@@ -1033,7 +1033,7 @@ func (s *Handlers) GetQueriesRunning(
 	ctx context.Context,
 	req serverhttp.GetQueriesRunningRequestObject,
 ) (serverhttp.GetQueriesRunningResponseObject, error) {
-	minDuration := 3
+	minDuration := 1000
 	if req.Params.MinDuration != nil {
 		minDuration = *req.Params.MinDuration
 	}

--- a/backend/internal/http/v1.go
+++ b/backend/internal/http/v1.go
@@ -1033,7 +1033,7 @@ func (s *Handlers) GetQueriesRunning(
 	ctx context.Context,
 	req serverhttp.GetQueriesRunningRequestObject,
 ) (serverhttp.GetQueriesRunningResponseObject, error) {
-	minDuration := 1000
+	minDuration := 10
 	if req.Params.MinDuration != nil {
 		minDuration = *req.Params.MinDuration
 	}

--- a/backend/internal/query/sql/queries/running/100000/running.tmpl.sql
+++ b/backend/internal/query/sql/queries/running/100000/running.tmpl.sql
@@ -12,6 +12,6 @@ FROM pg_stat_activity
 WHERE state <> 'idle'
   AND pid <> pg_backend_pid()
   AND datname = current_database()
-  AND NOW() - COALESCE(query_start, xact_start) > interval '{{ .MinDuration }} seconds'
+  AND NOW() - COALESCE(query_start, xact_start) > ({{ .MinDuration }} * interval '1 millisecond')
   AND query <> '<insufficient privilege>'
 ORDER BY COALESCE(query_start, xact_start) DESC

--- a/backend/internal/query/sql/queries/running/90600/running.tmpl.sql
+++ b/backend/internal/query/sql/queries/running/90600/running.tmpl.sql
@@ -12,6 +12,6 @@ FROM pg_stat_activity
 WHERE state <> 'idle'
   AND pid <> pg_backend_pid()
   AND datname = current_database()
-  AND NOW() - COALESCE(query_start, xact_start) > interval '{{ .MinDuration }} seconds'
+  AND NOW() - COALESCE(query_start, xact_start) > ({{ .MinDuration }} * interval '1 millisecond')
   AND query <> '<insufficient privilege>'
 ORDER BY COALESCE(query_start, xact_start) DESC

--- a/backend/internal/query/sql/queries/running/running.tmpl.sql
+++ b/backend/internal/query/sql/queries/running/running.tmpl.sql
@@ -12,6 +12,6 @@ FROM pg_stat_activity
 WHERE state <> 'idle'
   AND pid <> pg_backend_pid()
   AND datname = current_database()
-  AND NOW() - COALESCE(query_start, xact_start) > interval '{{ .MinDuration }} seconds'
+  AND NOW() - COALESCE(query_start, xact_start) > ({{ .MinDuration }} * interval '1 millisecond')
   AND query <> '<insufficient privilege>'
 ORDER BY COALESCE(query_start, xact_start) DESC

--- a/frontend/src/components/queries/RunningQueriesSection.vue
+++ b/frontend/src/components/queries/RunningQueriesSection.vue
@@ -21,7 +21,7 @@ const headers = computed(() => [
   { title: t('header.user'), key: 'User' },
   { title: t('header.backendType'), key: 'BackendType' },
 ])
-const minDuration = ref(1000)
+const minDuration = ref(10)
 const durationOptions = [0, 1, 5, 10, 50, 100, 500, 1000, 5000, 10000, 50000, 100000]
 
 const { items, loading } = useApiLoader<QueryRunning[]>(

--- a/frontend/src/components/queries/RunningQueriesSection.vue
+++ b/frontend/src/components/queries/RunningQueriesSection.vue
@@ -22,7 +22,7 @@ const headers = computed(() => [
   { title: t('header.backendType'), key: 'BackendType' },
 ])
 const minDuration = ref(1000)
-const durationOptions = [1000, 3000, 10000, 50000, 100000]
+const durationOptions = [1, 5, 10, 50, 100, 500, 1000, 5000, 10000, 50000, 100000]
 
 const { items, loading } = useApiLoader<QueryRunning[]>(
   () => getQueriesRunning({

--- a/frontend/src/components/queries/RunningQueriesSection.vue
+++ b/frontend/src/components/queries/RunningQueriesSection.vue
@@ -22,7 +22,7 @@ const headers = computed(() => [
   { title: t('header.backendType'), key: 'BackendType' },
 ])
 const minDuration = ref(1000)
-const durationOptions = [1, 5, 10, 50, 100, 500, 1000, 5000, 10000, 50000, 100000]
+const durationOptions = [0, 1, 5, 10, 50, 100, 500, 1000, 5000, 10000, 50000, 100000]
 
 const { items, loading } = useApiLoader<QueryRunning[]>(
   () => getQueriesRunning({

--- a/frontend/src/components/queries/RunningQueriesSection.vue
+++ b/frontend/src/components/queries/RunningQueriesSection.vue
@@ -21,8 +21,8 @@ const headers = computed(() => [
   { title: t('header.user'), key: 'User' },
   { title: t('header.backendType'), key: 'BackendType' },
 ])
-const minDuration = ref(3)
-const durationOptions = [3, 10, 100]
+const minDuration = ref(1000)
+const durationOptions = [1000, 3000, 10000, 50000, 100000]
 
 const { items, loading } = useApiLoader<QueryRunning[]>(
   () => getQueriesRunning({

--- a/frontend/src/locales/de_DE.json
+++ b/frontend/src/locales/de_DE.json
@@ -291,7 +291,7 @@
     "blockedProcesses": "Blockierte Prozesse: {count}"
   },
   "queries": {
-    "minDurationLabel": "Min. Dauer, Sek ≥"
+    "minDurationLabel": "Min. Dauer, ms ≥"
   },
   "indexes": {
     "all": "Alle Indizes",

--- a/frontend/src/locales/ru_RU.json
+++ b/frontend/src/locales/ru_RU.json
@@ -237,7 +237,7 @@
         "toastIdxHitRate": "Hit Rate индексов TOAST"
     },
     "queries": {
-        "minDurationLabel": "Мин. длительность, сек ≥"
+        "minDurationLabel": "Мин. длительность, мс ≥"
     },
     "indexes": {
         "all": "Все индексы",


### PR DESCRIPTION
Hi

I think it would be convenient to measure the duration of active query in milliseconds and expand the list to include all query (duration 0)

Set default minDuration equal 10 ms is optimal.