### PR TITLE
Add Kubernetes Gateway API support with TLS and HTTP redirect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## v0.1.25
+
+#### Breaking Changes
+- **Helm chart:** `ingress.tls.certManager.reflectToNamespace` removed. Reflector integration (emberstack `kubernetes-reflector`) is no longer rendered by the chart — if you need it, add the annotations manually via `ingress.annotations`. `ingress.tls.certNamespace` also removed; cert-manager `Certificate` is always created in the release namespace.
+
+#### Security
+- **Backend warning on auth without HTTPS:** `auth.NewMiddlewares` now emits a single zap WARNING at startup when `auth.mode != none && !require_https` — surfaces the case where credentials may be transmitted in plaintext. Added unit tests in `backend/internal/auth/auth_test.go` (4 cases covering enabled/disabled combinations).
+- **Auto-enable `require_https`:** Helm `configmap.yaml` injects `require_https: true` into rendered `dasha.yaml` when `auth.mode != none && tls.enabled` (via the new `dasha.tlsEnabled` helper which ORs `ingress.tls.enabled` and `gatewayAPI.tls.enabled`). Explicit `config.require_https: false` from values is preserved (escape hatch).
+- **Frontend nginx preserves original `X-Forwarded-Proto`:** the entrypoint writes a `map`-block to `/etc/nginx/conf.d/00-proto-map.conf` mapping `$http_x_forwarded_proto → $forwarded_proto` (with `$scheme` fallback when the header is absent). Both `proxy_pass` blocks (`/api/`, `/auth/`) now use `$forwarded_proto` instead of `$scheme`, so backend sees the proto terminated at ingress/gateway, not the in-cluster http. Previously the header was rewritten to `http` and silently broke `require_https`.
+
+#### Helm
+- **Defense-in-depth HTTP→HTTPS redirect:**
+  - Ingress: `nginx.ingress.kubernetes.io/ssl-redirect` and `force-ssl-redirect` annotations are auto-added when `ingress.tls.enabled && ingress.tls.redirect`.
+  - Gateway API: separate `HTTPRoute` with `RequestRedirect` filter on the HTTP listener (`tls.redirect: true`).
+  - Frontend nginx: `FORCE_HTTPS_REDIRECT=true` env (auto-set by chart at `tls.enabled`) injects an `if ($http_x_forwarded_proto = "http") { return 301 ... }` block into the server config. Requests without `X-Forwarded-Proto` (probes, port-forward) are not redirected.
+- **Conditional ingress/gateway routing:** chart now renders a single `/` rule → frontend service when `frontend.enabled: true` (frontend nginx handles path-routing internally) and two rules `/api/`, `/auth/` → backend only when `frontend.enabled: false` (headless deploy). Eliminates the previous double-routing between ingress and frontend nginx.
+- **Kubernetes Gateway API support** (`gateway.networking.k8s.io/v1`): new `gatewayAPI.*` values block, new templates `gateway.yaml`, `httproute.yaml`, `httproute-redirect.yaml`, `gateway-certificate.yaml`. Portable between Istio, NGINX Gateway Fabric, Envoy Gateway, Cilium. `ingress.enabled` and `gatewayAPI.enabled` are mutually exclusive — `helm template` fails via `dasha.validateTrafficMode` helper if both are true.
+- **New helpers in `_helpers.tpl`:** `dasha.tlsEnabled`, `dasha.validateTrafficMode`, `dasha.gatewayTLSSecretName`, `dasha.gatewayNamespace`.
+
 ## v0.1.24
 
 #### Security

--- a/CHANGELOG.ru.md
+++ b/CHANGELOG.ru.md
@@ -1,5 +1,24 @@
 # История изменений
 
+## v0.1.25
+
+#### Breaking changes
+- **Helm chart:** `ingress.tls.certManager.reflectToNamespace` удалён. Интеграция с reflector (emberstack `kubernetes-reflector`) больше не рендерится — если нужна, добавляйте аннотации руками через `ingress.annotations`. `ingress.tls.certNamespace` также удалён; cert-manager `Certificate` всегда создаётся в release namespace.
+
+#### Безопасность
+- **WARNING бэкенда при auth без HTTPS:** `auth.NewMiddlewares` теперь пишет один zap-WARNING при инициализации, если `auth.mode != none && !require_https` — подсвечивает случай, когда credentials передаются открытым текстом. Добавлены unit-тесты в `backend/internal/auth/auth_test.go` (4 кейса по комбинациям).
+- **Авто-включение `require_https`:** Helm-шаблон `configmap.yaml` инжектит `require_https: true` в рендеримый `dasha.yaml` при `auth.mode != none && tls.enabled` (через новый helper `dasha.tlsEnabled` — OR `ingress.tls.enabled` и `gatewayAPI.tls.enabled`). Явное `config.require_https: false` в values сохраняется (escape hatch).
+- **Frontend nginx сохраняет оригинальный `X-Forwarded-Proto`:** entrypoint пишет `map`-блок в `/etc/nginx/conf.d/00-proto-map.conf` (`$http_x_forwarded_proto → $forwarded_proto`, fallback на `$scheme` при отсутствии заголовка). Оба `proxy_pass` (`/api/`, `/auth/`) теперь используют `$forwarded_proto` вместо `$scheme` — бэкенд видит протокол, терминированный на ingress/gateway, а не внутрикластерный http. Раньше заголовок перезаписывался на `http` и тихо ломал `require_https`.
+
+#### Helm
+- **Defense-in-depth редирект HTTP→HTTPS:**
+  - Ingress: аннотации `nginx.ingress.kubernetes.io/ssl-redirect` и `force-ssl-redirect` авто-добавляются при `ingress.tls.enabled && ingress.tls.redirect`.
+  - Gateway API: отдельный `HTTPRoute` с filter `RequestRedirect` на HTTP-listener (`tls.redirect: true`).
+  - Frontend nginx: env `FORCE_HTTPS_REDIRECT=true` (авто-выставляется чартом при `tls.enabled`) подставляет блок `if ($http_x_forwarded_proto = "http") { return 301 ... }` в server-config. Запросы без `X-Forwarded-Proto` (probes, port-forward) не редиректятся.
+- **Условный routing в ingress/gateway:** чарт теперь рендерит **одно** правило `/` → frontend service при `frontend.enabled: true` (frontend nginx делает path-routing внутри), и два правила `/api/`, `/auth/` → backend только при `frontend.enabled: false` (headless deploy). Устраняет прежнее дублирование маршрутизации между ingress и frontend nginx.
+- **Поддержка Kubernetes Gateway API** (`gateway.networking.k8s.io/v1`): новый блок values `gatewayAPI.*`, новые шаблоны `gateway.yaml`, `httproute.yaml`, `httproute-redirect.yaml`, `gateway-certificate.yaml`. Портативно между Istio, NGINX Gateway Fabric, Envoy Gateway, Cilium. `ingress.enabled` и `gatewayAPI.enabled` взаимоисключаются — `helm template` падает через helper `dasha.validateTrafficMode`, если оба true.
+- **Новые helpers в `_helpers.tpl`:** `dasha.tlsEnabled`, `dasha.validateTrafficMode`, `dasha.gatewayTLSSecretName`, `dasha.gatewayNamespace`.
+
 ## v0.1.24
 
 #### Безопасность

--- a/README.md
+++ b/README.md
@@ -476,7 +476,7 @@ gatewayAPI:
   gatewayClassName: istio
   hostname: dasha.example.com
   # When the Gateway lives in a controller-specific namespace (e.g. istio-system),
-  # set gatewayNamespace and certManager.certNamespace accordingly.
+  # set gatewayNamespace accordingly — Certificate is created in the same namespace.
   # gatewayNamespace: istio-system
   tls:
     enabled: true

--- a/README.md
+++ b/README.md
@@ -486,7 +486,13 @@ gatewayAPI:
       # certNamespace: istio-system  # defaults to gatewayNamespace or release namespace
 ```
 
-The chart renders a `Gateway` resource with HTTP and HTTPS listeners, two `HTTPRoute` resources (main routing + HTTP→HTTPS redirect via `RequestRedirect` filter), and a cert-manager `Certificate`. `ingress.enabled` and `gatewayAPI.enabled` are mutually exclusive.
+Rendered resources (all conditional on `gatewayAPI.enabled: true`):
+- `Gateway` — HTTP listener always; HTTPS listener only when `gatewayAPI.tls.enabled: true`.
+- `HTTPRoute` (main) — attached to the HTTPS listener when `tls.enabled`, otherwise to the HTTP listener.
+- `HTTPRoute` (HTTP→HTTPS redirect, `RequestRedirect` filter) — only when `gatewayAPI.tls.enabled && gatewayAPI.tls.redirect`.
+- `Certificate` (cert-manager) — only when `gatewayAPI.tls.certManager.enabled`.
+
+`ingress.enabled` and `gatewayAPI.enabled` are mutually exclusive — `helm template` fails if both are true.
 
 #### API-only mode (without frontend)
 

--- a/README.md
+++ b/README.md
@@ -466,24 +466,27 @@ ingress:
 
 cert-manager will create a `Certificate` resource in the application namespace.
 
-#### Ingress with TLS (cert-manager + reflector)
+#### Gateway API with TLS (cert-manager)
 
-When the ingress controller runs in a different namespace (e.g. Istio), use `reflectToNamespace` to copy the TLS secret via [reflector](https://github.com/emberstack/kubernetes-reflector):
+Portable alternative to Ingress — works with any Gateway API implementation (Istio, NGINX Gateway Fabric, Envoy Gateway, Cilium):
 
 ```yaml
-ingress:
+gatewayAPI:
   enabled: true
-  className: istio
-  domain: dasha.example.com
+  gatewayClassName: istio
+  hostname: dasha.example.com
+  # When the Gateway lives in a controller-specific namespace (e.g. istio-system),
+  # set gatewayNamespace and certManager.certNamespace accordingly.
+  # gatewayNamespace: istio-system
   tls:
     enabled: true
     certManager:
       enabled: true
       issuer: cluster-issuer
-      reflectToNamespace: istio-ingress
+      # certNamespace: istio-system  # defaults to gatewayNamespace or release namespace
 ```
 
-In this mode, no separate `Certificate` resource is created. Instead, cert-manager annotations are added to the Ingress, and the generated TLS secret gets reflector annotations to be copied to the specified namespace.
+The chart renders a `Gateway` resource with HTTP and HTTPS listeners, two `HTTPRoute` resources (main routing + HTTP→HTTPS redirect via `RequestRedirect` filter), and a cert-manager `Certificate`. `ingress.enabled` and `gatewayAPI.enabled` are mutually exclusive.
 
 #### API-only mode (without frontend)
 
@@ -502,7 +505,7 @@ ingress:
 - **Passwords via env** — `password_from_env` + ESO or existing Kubernetes Secret
 - **Cloud SA keys** — per-folder `authorized_key.json` via ESO or existing Secret
 - **Frontend optional** — deploy backend only for API access
-- **Ingress** — `/api/` routed to backend, `/` to frontend (when enabled), cert-manager + reflector support
+- **Ingress / Gateway API** — single `/` rule routes to frontend (which proxies `/api/` and `/auth/` to backend); auto HTTP→HTTPS redirect when TLS is enabled; cert-manager support; mutually exclusive `gatewayAPI.enabled` for K8s Gateway API (`gateway.networking.k8s.io/v1`)
 - **Security** — `podSecurityContext`, `securityContext`, separate settings for frontend/backend
 
 ## CI/CD

--- a/README.md
+++ b/README.md
@@ -483,8 +483,9 @@ gatewayAPI:
     certManager:
       enabled: true
       issuer: cluster-issuer
-      # certNamespace: istio-system  # defaults to gatewayNamespace or release namespace
 ```
+
+The cert-manager `Certificate` is created in the Gateway's namespace (`gatewayNamespace`, defaults to the release namespace). Cross-namespace secret refs would require a `ReferenceGrant`, which the chart does not render — keeping Certificate and Gateway colocated avoids that.
 
 Rendered resources (all conditional on `gatewayAPI.enabled: true`):
 - `Gateway` — HTTP listener always; HTTPS listener only when `gatewayAPI.tls.enabled: true`.

--- a/README.ru.md
+++ b/README.ru.md
@@ -464,24 +464,27 @@ ingress:
 
 cert-manager создаст ресурс `Certificate` в namespace приложения.
 
-#### Ingress с TLS (cert-manager + reflector)
+#### Gateway API с TLS (cert-manager)
 
-Когда ingress controller работает в другом namespace (например, Istio), используйте `reflectToNamespace` для копирования TLS-секрета через [reflector](https://github.com/emberstack/kubernetes-reflector):
+Портативная альтернатива Ingress — работает с любой реализацией Gateway API (Istio, NGINX Gateway Fabric, Envoy Gateway, Cilium):
 
 ```yaml
-ingress:
+gatewayAPI:
   enabled: true
-  className: istio
-  domain: dasha.example.com
+  gatewayClassName: istio
+  hostname: dasha.example.com
+  # Если Gateway живёт в namespace контроллера (например, istio-system),
+  # задайте gatewayNamespace и certManager.certNamespace соответственно.
+  # gatewayNamespace: istio-system
   tls:
     enabled: true
     certManager:
       enabled: true
       issuer: cluster-issuer
-      reflectToNamespace: istio-ingress
+      # certNamespace: istio-system  # по умолчанию gatewayNamespace или release namespace
 ```
 
-В этом режиме отдельный ресурс `Certificate` не создаётся. Вместо этого на Ingress добавляются аннотации cert-manager, а сгенерированный TLS-секрет получает аннотации reflector для копирования в указанный namespace.
+Чарт рендерит ресурс `Gateway` с HTTP- и HTTPS-listeners, два `HTTPRoute` (основная маршрутизация + редирект HTTP→HTTPS через filter `RequestRedirect`) и cert-manager `Certificate`. `ingress.enabled` и `gatewayAPI.enabled` взаимоисключаются.
 
 #### Режим только API (без фронтенда)
 
@@ -500,7 +503,7 @@ ingress:
 - **Пароли через env** — `password_from_env` + ESO или существующий Kubernetes Secret
 - **Ключи сервисных аккаунтов** — отдельный `authorized_key.json` для каждого фолдера через ESO или существующий Secret
 - **Фронтенд опционален** — можно развернуть только бэкенд для доступа через API
-- **Ingress** — `/api/` маршрутизируется на бэкенд, `/` на фронтенд (когда включён), поддержка cert-manager + reflector
+- **Ingress / Gateway API** — одно правило `/` на фронтенд (который проксирует `/api/` и `/auth/` на бэкенд); авто-редирект HTTP→HTTPS при включённом TLS; поддержка cert-manager; взаимоисключающий `gatewayAPI.enabled` для K8s Gateway API (`gateway.networking.k8s.io/v1`)
 - **Безопасность** — `podSecurityContext`, `securityContext`, отдельные настройки для фронтенда и бэкенда
 
 ## CI/CD

--- a/README.ru.md
+++ b/README.ru.md
@@ -474,7 +474,7 @@ gatewayAPI:
   gatewayClassName: istio
   hostname: dasha.example.com
   # Если Gateway живёт в namespace контроллера (например, istio-system),
-  # задайте gatewayNamespace и certManager.certNamespace соответственно.
+  # задайте gatewayNamespace — Certificate создаётся в том же namespace.
   # gatewayNamespace: istio-system
   tls:
     enabled: true

--- a/README.ru.md
+++ b/README.ru.md
@@ -481,8 +481,9 @@ gatewayAPI:
     certManager:
       enabled: true
       issuer: cluster-issuer
-      # certNamespace: istio-system  # по умолчанию gatewayNamespace или release namespace
 ```
+
+`Certificate` от cert-manager создаётся в namespace Gateway (`gatewayNamespace`, по умолчанию — release namespace). Cross-namespace ссылки на secret потребовали бы `ReferenceGrant`, который чарт не рендерит — поэтому Certificate и Gateway держим в одном namespace.
 
 Рендеримые ресурсы (все условны от `gatewayAPI.enabled: true`):
 - `Gateway` — HTTP-listener всегда; HTTPS-listener только при `gatewayAPI.tls.enabled: true`.

--- a/README.ru.md
+++ b/README.ru.md
@@ -484,7 +484,13 @@ gatewayAPI:
       # certNamespace: istio-system  # по умолчанию gatewayNamespace или release namespace
 ```
 
-Чарт рендерит ресурс `Gateway` с HTTP- и HTTPS-listeners, два `HTTPRoute` (основная маршрутизация + редирект HTTP→HTTPS через filter `RequestRedirect`) и cert-manager `Certificate`. `ingress.enabled` и `gatewayAPI.enabled` взаимоисключаются.
+Рендеримые ресурсы (все условны от `gatewayAPI.enabled: true`):
+- `Gateway` — HTTP-listener всегда; HTTPS-listener только при `gatewayAPI.tls.enabled: true`.
+- `HTTPRoute` (основной) — привязан к HTTPS-listener при `tls.enabled`, иначе к HTTP-listener.
+- `HTTPRoute` (редирект HTTP→HTTPS, filter `RequestRedirect`) — только при `gatewayAPI.tls.enabled && gatewayAPI.tls.redirect`.
+- `Certificate` (cert-manager) — только при `gatewayAPI.tls.certManager.enabled`.
+
+`ingress.enabled` и `gatewayAPI.enabled` взаимоисключаются — `helm template` падает, если оба true.
 
 #### Режим только API (без фронтенда)
 

--- a/backend/internal/auth/auth.go
+++ b/backend/internal/auth/auth.go
@@ -41,6 +41,13 @@ func (m *Middlewares) Stop() {
 }
 
 func NewMiddlewares(ctx context.Context, cfg config.AuthConfig, logger *zap.Logger) (*Middlewares, error) {
+	if cfg.Mode != config.AuthModeNone && cfg.Mode != "" && !cfg.RequireHTTPS {
+		logger.Warn(
+			"auth enabled without require_https — credentials may be transmitted in plaintext",
+			zap.String("auth_mode", string(cfg.Mode)),
+		)
+	}
+
 	var (
 		oidcProvider *OIDCProvider
 		sessionMgr   *SessionManager

--- a/backend/internal/auth/auth_test.go
+++ b/backend/internal/auth/auth_test.go
@@ -1,0 +1,105 @@
+package auth
+
+import (
+	"context"
+	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/dbulashev/dasha/internal/config"
+)
+
+const noHTTPSWarnMsg = "auth enabled without require_https — credentials may be transmitted in plaintext"
+
+func TestNewMiddlewares_WarnsWhenAuthWithoutHTTPS(t *testing.T) {
+	core, logs := observer.New(zap.WarnLevel)
+	logger := zap.New(core)
+
+	cfg := config.AuthConfig{
+		Mode:         config.AuthModeToken,
+		RequireHTTPS: false,
+		Tokens: []config.AuthToken{
+			{Name: "test", Token: "secret", Role: "viewer"},
+		},
+	}
+
+	mw, err := NewMiddlewares(context.Background(), cfg, logger)
+	if err != nil {
+		t.Fatalf("NewMiddlewares: %v", err)
+	}
+	defer mw.Stop()
+
+	warns := logs.FilterMessage(noHTTPSWarnMsg).All()
+	if len(warns) != 1 {
+		t.Fatalf("expected 1 warning, got %d", len(warns))
+	}
+
+	mode, ok := warns[0].ContextMap()["auth_mode"].(string)
+	if !ok || mode != "token" {
+		t.Errorf("expected auth_mode=token in log fields, got %v", warns[0].ContextMap()["auth_mode"])
+	}
+}
+
+func TestNewMiddlewares_NoWarnWhenAuthDisabled(t *testing.T) {
+	core, logs := observer.New(zap.WarnLevel)
+	logger := zap.New(core)
+
+	cfg := config.AuthConfig{
+		Mode:         config.AuthModeNone,
+		RequireHTTPS: false,
+	}
+
+	mw, err := NewMiddlewares(context.Background(), cfg, logger)
+	if err != nil {
+		t.Fatalf("NewMiddlewares: %v", err)
+	}
+	defer mw.Stop()
+
+	if got := logs.FilterMessage(noHTTPSWarnMsg).Len(); got != 0 {
+		t.Errorf("expected no warnings, got %d", got)
+	}
+}
+
+func TestNewMiddlewares_NoWarnWhenAuthModeEmpty(t *testing.T) {
+	core, logs := observer.New(zap.WarnLevel)
+	logger := zap.New(core)
+
+	cfg := config.AuthConfig{
+		Mode:         "",
+		RequireHTTPS: false,
+	}
+
+	mw, err := NewMiddlewares(context.Background(), cfg, logger)
+	if err != nil {
+		t.Fatalf("NewMiddlewares: %v", err)
+	}
+	defer mw.Stop()
+
+	if got := logs.FilterMessage(noHTTPSWarnMsg).Len(); got != 0 {
+		t.Errorf("expected no warnings, got %d", got)
+	}
+}
+
+func TestNewMiddlewares_NoWarnWhenRequireHTTPSEnabled(t *testing.T) {
+	core, logs := observer.New(zap.WarnLevel)
+	logger := zap.New(core)
+
+	cfg := config.AuthConfig{
+		Mode:         config.AuthModeToken,
+		RequireHTTPS: true,
+		Tokens: []config.AuthToken{
+			{Name: "test", Token: "secret", Role: "viewer"},
+		},
+	}
+
+	mw, err := NewMiddlewares(context.Background(), cfg, logger)
+	if err != nil {
+		t.Fatalf("NewMiddlewares: %v", err)
+	}
+	defer mw.Stop()
+
+	if got := logs.FilterMessage(noHTTPSWarnMsg).Len(); got != 0 {
+		t.Errorf("expected no warnings, got %d", got)
+	}
+}

--- a/deploy/charts/dasha/templates/_helpers.tpl
+++ b/deploy/charts/dasha/templates/_helpers.tpl
@@ -94,6 +94,22 @@ Invoke from a guaranteed-rendered template (e.g. configmap.yaml).
 {{- end -}}
 
 {{/*
+Validate Gateway API configuration. When Gateway lives in a different namespace
+than the release (e.g. istio-system), allowedRoutes.namespaces.from must NOT be "Same"
+or HTTPRoute from the release namespace cannot attach to the Gateway.
+*/}}
+{{- define "dasha.validateGatewayAPI" -}}
+{{- if .Values.gatewayAPI.enabled -}}
+{{- $gwNs := .Values.gatewayAPI.gatewayNamespace -}}
+{{- $releaseNs := include "dasha.namespace" . -}}
+{{- $from := dig "namespaces" "from" "Same" .Values.gatewayAPI.allowedRoutes -}}
+{{- if and $gwNs (ne $gwNs $releaseNs) (eq $from "Same") -}}
+{{- fail (printf "gatewayAPI.gatewayNamespace=%q differs from release namespace %q, but gatewayAPI.allowedRoutes.namespaces.from=\"Same\" — HTTPRoute cannot attach. Set allowedRoutes.namespaces.from to \"All\" or \"Selector\"." $gwNs $releaseNs) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 TLS secret name for the Gateway. Defaults to {fullname}-tls when not set explicitly.
 */}}
 {{- define "dasha.gatewayTLSSecretName" -}}

--- a/deploy/charts/dasha/templates/_helpers.tpl
+++ b/deploy/charts/dasha/templates/_helpers.tpl
@@ -74,6 +74,40 @@ Frontend image
 {{- end }}
 
 {{/*
+Whether TLS is enabled at the ingress / gateway layer.
+Returns "true" or "false" (string — use with eq).
+*/}}
+{{- define "dasha.tlsEnabled" -}}
+{{- $ingressTLS := and .Values.ingress.enabled .Values.ingress.tls.enabled -}}
+{{- $gwTLS := and .Values.gatewayAPI.enabled .Values.gatewayAPI.tls.enabled -}}
+{{- ternary "true" "false" (or $ingressTLS $gwTLS) -}}
+{{- end -}}
+
+{{/*
+Fail if both Ingress and Gateway API are enabled — they are mutually exclusive.
+Invoke from a guaranteed-rendered template (e.g. configmap.yaml).
+*/}}
+{{- define "dasha.validateTrafficMode" -}}
+{{- if and .Values.ingress.enabled .Values.gatewayAPI.enabled -}}
+{{- fail "ingress.enabled and gatewayAPI.enabled are mutually exclusive — set only one to true" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+TLS secret name for the Gateway. Defaults to {fullname}-tls when not set explicitly.
+*/}}
+{{- define "dasha.gatewayTLSSecretName" -}}
+{{- .Values.gatewayAPI.tls.certificateRef.name | default (printf "%s-tls" (include "dasha.fullname" .)) -}}
+{{- end -}}
+
+{{/*
+Gateway resource namespace. Defaults to release namespace when not set.
+*/}}
+{{- define "dasha.gatewayNamespace" -}}
+{{- .Values.gatewayAPI.gatewayNamespace | default (include "dasha.namespace" .) -}}
+{{- end -}}
+
+{{/*
 Name of the secret containing password env vars
 */}}
 {{- define "dasha.envSecretName" -}}

--- a/deploy/charts/dasha/templates/configmap.yaml
+++ b/deploy/charts/dasha/templates/configmap.yaml
@@ -1,10 +1,13 @@
 {{- include "dasha.validateTrafficMode" . -}}
+{{- include "dasha.validateGatewayAPI" . -}}
 {{- $config := deepCopy .Values.config -}}
-{{- $authMode := dig "auth" "mode" "none" $config -}}
+{{- $auth := default dict (get $config "auth") -}}
+{{- $authMode := default "none" (get $auth "mode") -}}
 {{- $authEnabled := and (ne $authMode "none") (ne $authMode "") -}}
 {{- $tlsEnabled := eq (include "dasha.tlsEnabled" .) "true" -}}
-{{- if and $authEnabled $tlsEnabled (not (hasKey $config "require_https")) -}}
-{{- $_ := set $config "require_https" true -}}
+{{- if and $authEnabled $tlsEnabled (not (hasKey $auth "require_https")) -}}
+{{- $_ := set $auth "require_https" true -}}
+{{- $_ := set $config "auth" $auth -}}
 {{- end }}
 ---
 apiVersion: v1

--- a/deploy/charts/dasha/templates/configmap.yaml
+++ b/deploy/charts/dasha/templates/configmap.yaml
@@ -1,3 +1,11 @@
+{{- include "dasha.validateTrafficMode" . -}}
+{{- $config := deepCopy .Values.config -}}
+{{- $authMode := dig "auth" "mode" "none" $config -}}
+{{- $authEnabled := and (ne $authMode "none") (ne $authMode "") -}}
+{{- $tlsEnabled := eq (include "dasha.tlsEnabled" .) "true" -}}
+{{- if and $authEnabled $tlsEnabled (not (hasKey $config "require_https")) -}}
+{{- $_ := set $config "require_https" true -}}
+{{- end }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -8,4 +16,4 @@ metadata:
     {{- include "dasha.labels" $ | nindent 4 }}
 data:
   dasha.yaml: |
-    {{- .Values.config | toYaml | nindent 4 }}
+    {{- $config | toYaml | nindent 4 }}

--- a/deploy/charts/dasha/templates/frontend-deployment.yaml
+++ b/deploy/charts/dasha/templates/frontend-deployment.yaml
@@ -64,6 +64,8 @@ spec:
           env:
             - name: BACKEND_URL
               value: {{ template "dasha.fullname" $ }}-backend:{{ .Values.backend.port }}
+            - name: FORCE_HTTPS_REDIRECT
+              value: {{ include "dasha.tlsEnabled" . | quote }}
           volumeMounts:
             - name: nginx-cache
               mountPath: /var/cache/nginx

--- a/deploy/charts/dasha/templates/gateway-certificate.yaml
+++ b/deploy/charts/dasha/templates/gateway-certificate.yaml
@@ -4,7 +4,9 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{ include "dasha.fullname" . }}-gateway-tls
-  namespace: {{ .Values.gatewayAPI.tls.certManager.certNamespace | default (include "dasha.gatewayNamespace" .) }}
+  # Certificate is always created in the Gateway's namespace — Gateway listener references
+  # the secret by name only, and cross-namespace secret refs would require a ReferenceGrant.
+  namespace: {{ include "dasha.gatewayNamespace" . }}
   labels:
     {{- include "dasha.labels" . | nindent 4 }}
 spec:

--- a/deploy/charts/dasha/templates/gateway-certificate.yaml
+++ b/deploy/charts/dasha/templates/gateway-certificate.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.gatewayAPI.enabled .Values.gatewayAPI.tls.enabled .Values.gatewayAPI.tls.certManager.enabled }}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "dasha.fullname" . }}-gateway-tls
+  namespace: {{ .Values.gatewayAPI.tls.certManager.certNamespace | default (include "dasha.gatewayNamespace" .) }}
+  labels:
+    {{- include "dasha.labels" . | nindent 4 }}
+spec:
+  dnsNames:
+    - {{ .Values.gatewayAPI.hostname }}
+  issuerRef:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    name: {{ .Values.gatewayAPI.tls.certManager.issuer }}
+  secretName: {{ include "dasha.gatewayTLSSecretName" . }}
+{{- end }}

--- a/deploy/charts/dasha/templates/gateway.yaml
+++ b/deploy/charts/dasha/templates/gateway.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.gatewayAPI.enabled }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: {{ include "dasha.fullname" . }}
+  namespace: {{ include "dasha.gatewayNamespace" . }}
+  labels:
+    {{- include "dasha.labels" . | nindent 4 }}
+  {{- if and .Values.gatewayAPI.tls.enabled .Values.gatewayAPI.tls.certManager.enabled }}
+  annotations:
+    cert-manager.io/cluster-issuer: {{ .Values.gatewayAPI.tls.certManager.issuer }}
+  {{- end }}
+spec:
+  gatewayClassName: {{ .Values.gatewayAPI.gatewayClassName }}
+  listeners:
+    - name: http
+      port: 80
+      protocol: HTTP
+      hostname: {{ .Values.gatewayAPI.hostname }}
+      allowedRoutes:
+        {{- toYaml .Values.gatewayAPI.allowedRoutes | nindent 8 }}
+    {{- if .Values.gatewayAPI.tls.enabled }}
+    - name: https
+      port: 443
+      protocol: HTTPS
+      hostname: {{ .Values.gatewayAPI.hostname }}
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: {{ .Values.gatewayAPI.tls.certificateRef.kind }}
+            name: {{ include "dasha.gatewayTLSSecretName" . }}
+      allowedRoutes:
+        {{- toYaml .Values.gatewayAPI.allowedRoutes | nindent 8 }}
+    {{- end }}
+{{- end }}

--- a/deploy/charts/dasha/templates/httproute-redirect.yaml
+++ b/deploy/charts/dasha/templates/httproute-redirect.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.gatewayAPI.enabled .Values.gatewayAPI.tls.enabled .Values.gatewayAPI.tls.redirect }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "dasha.fullname" . }}-redirect
+  namespace: {{ include "dasha.namespace" . }}
+  labels:
+    {{- include "dasha.labels" . | nindent 4 }}
+spec:
+  parentRefs:
+    - name: {{ include "dasha.fullname" . }}
+      namespace: {{ include "dasha.gatewayNamespace" . }}
+      sectionName: http
+  hostnames:
+    - {{ .Values.gatewayAPI.hostname }}
+  rules:
+    - filters:
+        - type: RequestRedirect
+          requestRedirect:
+            scheme: https
+            statusCode: 301
+{{- end }}

--- a/deploy/charts/dasha/templates/httproute.yaml
+++ b/deploy/charts/dasha/templates/httproute.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.gatewayAPI.enabled }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "dasha.fullname" . }}
+  namespace: {{ include "dasha.namespace" . }}
+  labels:
+    {{- include "dasha.labels" . | nindent 4 }}
+spec:
+  parentRefs:
+    - name: {{ include "dasha.fullname" . }}
+      namespace: {{ include "dasha.gatewayNamespace" . }}
+      sectionName: {{ ternary "https" "http" .Values.gatewayAPI.tls.enabled }}
+  hostnames:
+    - {{ .Values.gatewayAPI.hostname }}
+  rules:
+    {{- if .Values.frontend.enabled }}
+    # Frontend nginx handles path-routing internally (/api/, /auth/ → backend, / → SPA).
+    - backendRefs:
+        - name: {{ include "dasha.fullname" . }}-frontend
+          port: {{ .Values.frontend.port }}
+    {{- else }}
+    # Headless deploy (no UI): route API and auth callbacks directly to backend.
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /api/
+      backendRefs:
+        - name: {{ include "dasha.fullname" . }}-backend
+          port: {{ .Values.backend.port }}
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /auth/
+      backendRefs:
+        - name: {{ include "dasha.fullname" . }}-backend
+          port: {{ .Values.backend.port }}
+    {{- end }}
+{{- end }}

--- a/deploy/charts/dasha/templates/ingress.yaml
+++ b/deploy/charts/dasha/templates/ingress.yaml
@@ -1,11 +1,11 @@
 {{- if .Values.ingress.enabled }}
-{{- if and .Values.ingress.tls.enabled .Values.ingress.tls.certManager.enabled (not .Values.ingress.tls.certManager.reflectToNamespace) }}
+{{- if and .Values.ingress.tls.enabled .Values.ingress.tls.certManager.enabled }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{ template "dasha.fullname" $ }}-tls
-  namespace: {{ .Values.ingress.tls.certNamespace }}
+  namespace: {{ template "dasha.namespace" $ }}
 spec:
   dnsNames:
     - {{ .Values.ingress.domain }}
@@ -24,17 +24,12 @@ metadata:
   labels:
     {{- include "dasha.labels" $ | nindent 4 }}
   {{- $annotations := dict }}
+  {{- if and .Values.ingress.tls.enabled .Values.ingress.tls.redirect }}
+  {{- $_ := set $annotations "nginx.ingress.kubernetes.io/ssl-redirect" "true" }}
+  {{- $_ := set $annotations "nginx.ingress.kubernetes.io/force-ssl-redirect" "true" }}
+  {{- end }}
   {{- if and .Values.ingress.tls.enabled .Values.ingress.tls.certManager.enabled }}
   {{- $_ := set $annotations "cert-manager.io/cluster-issuer" .Values.ingress.tls.certManager.issuer }}
-  {{- if .Values.ingress.tls.certManager.reflectToNamespace }}
-  {{- $reflectorAnnotations := dict
-    "reflector.v1.k8s.emberstack.com/reflection-allowed" "true"
-    "reflector.v1.k8s.emberstack.com/reflection-auto-enabled" "true"
-    "reflector.v1.k8s.emberstack.com/reflection-auto-namespaces" .Values.ingress.tls.certManager.reflectToNamespace
-    "reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces" .Values.ingress.tls.certManager.reflectToNamespace
-  }}
-  {{- $__ := set $annotations "cert-manager.io/secret-template" ($reflectorAnnotations | toJson) }}
-  {{- end }}
   {{- end }}
   {{- with .Values.ingress.annotations }}
   {{- $annotations = merge $annotations . }}
@@ -57,7 +52,17 @@ spec:
     - host: {{ .Values.ingress.domain }}
       http:
         paths:
-          # /api/ must come before / for correct routing
+          {{- if .Values.frontend.enabled }}
+          # Frontend nginx handles path-routing internally (/api/, /auth/ → backend, / → SPA).
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ template "dasha.fullname" $ }}-frontend
+                port:
+                  name: http
+          {{- else }}
+          # Headless deploy (no UI): route API and auth callbacks directly to backend.
           - path: /api/
             pathType: Prefix
             backend:
@@ -65,12 +70,11 @@ spec:
                 name: {{ template "dasha.fullname" $ }}-backend
                 port:
                   name: http
-          {{- if .Values.frontend.enabled }}
-          - path: /
+          - path: /auth/
             pathType: Prefix
             backend:
               service:
-                name: {{ template "dasha.fullname" $ }}-frontend
+                name: {{ template "dasha.fullname" $ }}-backend
                 port:
                   name: http
           {{- end }}

--- a/deploy/charts/dasha/values.yaml
+++ b/deploy/charts/dasha/values.yaml
@@ -165,13 +165,41 @@ ingress:
   tls:
     enabled: false
     secretName: ""
-    certNamespace: ""
+    # Auto-add nginx-ingress ssl-redirect annotations when tls is enabled.
+    # Set to false if you want to serve plain HTTP alongside HTTPS.
+    redirect: true
     # cert-manager integration
     certManager:
       enabled: false
       issuer: cluster-issuer
-      # if set, adds reflector annotations to copy the TLS secret to this namespace
-      reflectToNamespace: ""
+
+# -- Kubernetes Gateway API (gateway.networking.k8s.io/v1)
+# Portable alternative to Ingress. Mutually exclusive with ingress.enabled.
+gatewayAPI:
+  enabled: false
+  # gatewayClassName: istio | nginx | envoy | cilium | ...
+  gatewayClassName: istio
+  hostname: dasha.example.com
+  # Namespace for the Gateway resource. Empty = release namespace.
+  # Some implementations (e.g. Istio) expect the Gateway in the same namespace as the controller (istio-system).
+  gatewayNamespace: ""
+  # AllowedRoutes for cross-namespace HTTPRoute attachment.
+  allowedRoutes:
+    namespaces:
+      from: Same  # Same | Selector | All
+  tls:
+    enabled: false
+    certificateRef:
+      kind: Secret
+      # name: defaults to {fullname}-tls
+      name: ""
+    certManager:
+      enabled: false
+      issuer: cluster-issuer
+      # Namespace where Certificate is created. Empty = gatewayNamespace (or release namespace).
+      certNamespace: ""
+    # Auto-create an HTTPRoute with RequestRedirect filter on the HTTP listener.
+    redirect: true
 
 nameOverride: ""
 fullnameOverride: ""

--- a/deploy/charts/dasha/values.yaml
+++ b/deploy/charts/dasha/values.yaml
@@ -196,8 +196,6 @@ gatewayAPI:
     certManager:
       enabled: false
       issuer: cluster-issuer
-      # Namespace where Certificate is created. Empty = gatewayNamespace (or release namespace).
-      certNamespace: ""
     # Auto-create an HTTPRoute with RequestRedirect filter on the HTTP listener.
     redirect: true
 

--- a/deploy/images/docker-entrypoint.sh
+++ b/deploy/images/docker-entrypoint.sh
@@ -3,6 +3,24 @@ set -e
 
 export BACKEND_URL="${BACKEND_URL:-backend:8000}"
 
-envsubst '${BACKEND_URL}' < /etc/nginx/templates/nginx.conf.template > /etc/nginx/conf.d/default.conf
+# Preserve original X-Forwarded-Proto when proxied through ingress/gateway;
+# fall back to $scheme when the header is absent (compose, port-forward).
+cat > /etc/nginx/conf.d/00-proto-map.conf <<'EOF'
+map $http_x_forwarded_proto $forwarded_proto {
+    default $http_x_forwarded_proto;
+    ""      $scheme;
+}
+EOF
+
+# Defense-in-depth: redirect HTTP→HTTPS at the pod level if the chart signals TLS upstream.
+# Only redirect requests that explicitly arrived via http through a proxy — requests without
+# X-Forwarded-Proto (probes, port-forward) are left alone.
+if [ "${FORCE_HTTPS_REDIRECT:-false}" = "true" ]; then
+    export HTTPS_REDIRECT_BLOCK='if ($http_x_forwarded_proto = "http") { return 301 https://$host$request_uri; }'
+else
+    export HTTPS_REDIRECT_BLOCK=''
+fi
+
+envsubst '${BACKEND_URL} ${HTTPS_REDIRECT_BLOCK}' < /etc/nginx/templates/nginx.conf.template > /etc/nginx/conf.d/default.conf
 
 exec nginx -g 'daemon off;'

--- a/deploy/images/nginx.conf.template
+++ b/deploy/images/nginx.conf.template
@@ -2,12 +2,14 @@ server {
     listen 3000;
     server_name _;
 
+    ${HTTPS_REDIRECT_BLOCK}
+
     location /api/ {
         proxy_pass http://${BACKEND_URL}/api/;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto $forwarded_proto;
         proxy_connect_timeout 5s;
         proxy_read_timeout 30s;
         proxy_buffer_size 16k;
@@ -19,7 +21,7 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto $forwarded_proto;
         proxy_connect_timeout 5s;
         proxy_read_timeout 30s;
         proxy_buffer_size 16k;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Kubernetes Gateway API support with mutual-exclusion vs Ingress, Gateway TLS, hostname/routing controls, and HTTP→HTTPS redirect rendering; frontend gets an opt-in HTTPS redirect flag.

* **Security**
  * Backend logs a warning when auth is enabled without HTTPS; chart can auto-set require_https and frontend preserves original protocol header for correct proxying.

* **Breaking Changes**
  * Removed reflector-based cert-manager options; certificates are now created in the release namespace.

* **Documentation**
  * Chart README updated with Gateway API/TLS guidance and mutual-exclusion notes.

* **Tests**
  * Added unit tests verifying the auth-without-HTTPS warning.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dbulashev/dasha/pull/47?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->