### PR TITLE
fix hs

### DIFF
--- a/backend/internal/metrics/collector.go
+++ b/backend/internal/metrics/collector.go
@@ -47,7 +47,7 @@ var CoreSignals = []SignalKind{
 	SigMaxBloatRatio, SigSeqExhaustionMax, SigTypeExhaustionMax,
 	SigLatencyMs, SigSeqScanRate,
 	SigLoadAvg15, SigNumVCPU, SigDiskUsedRatio,
-	SigPoolerClients, SigPoolerServers, SigPoolerPoolSize,
+	SigPoolerServers, SigPoolerPoolSize,
 }
 
 // signalRole maps a signal to the provider-role that serves it.

--- a/backend/internal/metrics/collector_test.go
+++ b/backend/internal/metrics/collector_test.go
@@ -6,6 +6,9 @@ import (
 	"time"
 )
 
+// sigUncatalogued has no catalog template under any provider.
+const sigUncatalogued SignalKind = "test_uncatalogued"
+
 // valueClient returns a fixed value for any non-empty expression.
 type valueClient struct{ v float64 }
 
@@ -40,7 +43,7 @@ func TestCollector_InstantCollectsCataloguedSignals(t *testing.T) {
 	co := newTestCollector(t, 42)
 
 	sig, err := co.Instant(context.Background(), "prod-mdb", "rc1a-abc.mdb.yandexcloud.net", time.Now(),
-		SigXactsLeftWrap, SigIOReadTime)
+		SigXactsLeftWrap, sigUncatalogued)
 	if err != nil {
 		t.Fatalf("Instant: %v", err)
 	}
@@ -50,9 +53,8 @@ func TestCollector_InstantCollectsCataloguedSignals(t *testing.T) {
 		t.Errorf("SigXactsLeftWrap: want present/42, got v=%v ok=%v", v, ok)
 	}
 
-	// io_read_time has no catalog template -> absent (graceful).
-	if _, ok := sig.Get(SigIOReadTime); ok {
-		t.Errorf("SigIOReadTime should be absent (uncatalogued), got present")
+	if _, ok := sig.Get(sigUncatalogued); ok {
+		t.Errorf("uncatalogued signal should be absent, got present")
 	}
 }
 

--- a/backend/internal/metrics/signals.go
+++ b/backend/internal/metrics/signals.go
@@ -7,9 +7,7 @@ type SignalKind string
 
 const (
 	// performance
-	SigLatencyMs     SignalKind = "latency_ms"        // calls-weighted mean | pooler p95
-	SigIOReadTime    SignalKind = "io_read_time_rate" // pg_stat_io (PG16+)
-	SigIOWriteTime   SignalKind = "io_write_time_rate"
+	SigLatencyMs     SignalKind = "latency_ms"      // calls-weighted mean | pooler p95
 	SigCacheHitRatio SignalKind = "cache_hit_ratio" // secondary
 
 	// connections / saturation


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined default metrics collection to exclude pooler client signals while continuing to collect pooler server and pool-size metrics.
  * Ensured uncatalogued metrics are omitted from instant collection results.
* **Style**
  * Cleaned up formatting in the latency metric definition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->