### PR TITLE
Using official docker image of pgSCV

### DIFF
--- a/demo/docker-compose.metrics.yaml
+++ b/demo/docker-compose.metrics.yaml
@@ -44,9 +44,7 @@ services:
     restart: unless-stopped
 
   pgscv:
-    build:
-      context: https://github.com/CHERTS/pgscv.git#v0.15.2
-    image: dasha/pgscv:local
+    image: cherts/pgscv:v0.15.3
     container_name: dasha-pgscv
     privileged: true # system collector needs host visibility
     command:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the metrics demo to use the published `pgscv` version 0.15.3 image.
  * Removed the local image build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->